### PR TITLE
The CreatePool fucnt has targetDedicated of type int? (int of nullable type)

### DIFF
--- a/articles/batch/batch-application-packages.md
+++ b/articles/batch/batch-application-packages.md
@@ -198,7 +198,7 @@ In Batch .NET, specify one or more [CloudPool][net_cloudpool].[ApplicationPackag
 CloudPool myCloudPool =
     batchClient.PoolOperations.CreatePool(
         poolId: "myPool",
-        targetDedicated: "1",
+        targetDedicated: 1,
         virtualMachineSize: "small",
         cloudServiceConfiguration: new CloudServiceConfiguration(osFamily: "4"));
 


### PR DESCRIPTION
Currently this is passed as strinng i.e. like this: ```targetDeicated = "1"``` this should actually be ```targetDedicated = 1```.

Reason:

CreatePool all the overrides take targetDedicated of int type. 

Making the sample uptodate so that it works for anyone copy pasting.

Thanks,
^Tats